### PR TITLE
Revert "move out oslo.service"

### DIFF
--- a/ceilometer/cmd/agent_notification.py
+++ b/ceilometer/cmd/agent_notification.py
@@ -14,8 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import cotyledon
-from cotyledon import oslo_config_glue
+from oslo_service import service as os_service
 
 from ceilometer import notification
 from ceilometer import service
@@ -23,9 +22,5 @@ from ceilometer import service
 
 def main():
     conf = service.prepare_service()
-
-    sm = cotyledon.ServiceManager()
-    sm.add(notification.NotificationService,
-           workers=conf.notification.workers, args=(conf,))
-    oslo_config_glue.setup(sm, conf)
-    sm.run()
+    os_service.launch(conf, notification.NotificationService(),
+                      workers=conf.notification.workers).wait()

--- a/ceilometer/cmd/collector.py
+++ b/ceilometer/cmd/collector.py
@@ -14,8 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import cotyledon
-from cotyledon import oslo_config_glue
+from oslo_service import service as os_service
 
 from ceilometer import collector
 from ceilometer import service
@@ -23,8 +22,5 @@ from ceilometer import service
 
 def main():
     conf = service.prepare_service()
-    sm = cotyledon.ServiceManager()
-    sm.add(collector.CollectorService, workers=conf.collector.workers,
-           args=(conf,))
-    oslo_config_glue.setup(sm, conf)
-    sm.run()
+    os_service.launch(conf, collector.CollectorService(),
+                      workers=conf.collector.workers).wait()

--- a/ceilometer/cmd/polling.py
+++ b/ceilometer/cmd/polling.py
@@ -14,10 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import cotyledon
-from cotyledon import oslo_config_glue
 from oslo_config import cfg
 from oslo_log import log
+from oslo_service import service as os_service
 
 from ceilometer.agent import manager
 from ceilometer.i18n import _LW
@@ -75,18 +74,9 @@ CLI_OPTS = [
 ]
 
 
-def create_polling_service(worker_id, conf):
-    return manager.AgentManager(worker_id,
-                                conf,
-                                conf.polling_namespaces,
-                                conf.pollster_list)
-
-
 def main():
     conf = cfg.ConfigOpts()
     conf.register_cli_opts(CLI_OPTS)
     service.prepare_service(conf=conf)
-    sm = cotyledon.ServiceManager()
-    sm.add(create_polling_service, args=(conf,))
-    oslo_config_glue.setup(sm, conf)
-    sm.run()
+    os_service.launch(conf, manager.AgentManager(conf, conf.polling_namespaces,
+                                                 conf.pollster_list)).wait()

--- a/ceilometer/collector.py
+++ b/ceilometer/collector.py
@@ -17,7 +17,6 @@ from itertools import chain
 import select
 import socket
 
-import cotyledon
 import msgpack
 from oslo_config import cfg
 from oslo_log import log
@@ -29,6 +28,7 @@ from ceilometer import dispatcher
 from ceilometer.i18n import _, _LE, _LW
 from ceilometer import messaging
 from ceilometer.publisher import utils as publisher_utils
+from ceilometer import service_base
 from ceilometer import utils
 
 OPTS = [
@@ -58,19 +58,23 @@ OPTS = [
 LOG = log.getLogger(__name__)
 
 
-class CollectorService(cotyledon.Service):
+class CollectorService(service_base.ServiceBase):
     """Listener for the collector service."""
-    def __init__(self, worker_id, conf):
-        super(CollectorService, self).__init__(worker_id)
+
+    def __init__(self, conf):
+        super(CollectorService, self).__init__()
         self.conf = conf
+
+    def start(self):
+        """Bind the UDP socket and handle incoming data."""
         # ensure dispatcher is configured before starting other services
         dispatcher_managers = dispatcher.load_dispatcher_manager(conf)
         (self.meter_manager, self.event_manager) = dispatcher_managers
         self.sample_listener = None
         self.event_listener = None
         self.udp_thread = None
+        super(CollectorService, self).start()
 
-    def run(self):
         if self.conf.collector.udp_address:
             self.udp_thread = utils.spawn_thread(self.start_udp)
 
@@ -144,15 +148,16 @@ class CollectorService(cotyledon.Service):
                     LOG.warning(_LW('sample signature invalid, '
                                     'discarding: %s'), sample)
 
-    def terminate(self):
-        if self.sample_listener:
-            utils.kill_listeners([self.sample_listener])
-        if self.event_listener:
-            utils.kill_listeners([self.event_listener])
-        if self.udp_thread:
-            self.udp_run = False
-            self.udp_thread.join()
-        super(CollectorService, self).terminate()
+    def stop(self):
+        if self.started:
+            if self.sample_listener:
+                utils.kill_listeners([self.sample_listener])
+            if self.event_listener:
+                utils.kill_listeners([self.event_listener])
+            if self.udp_thread:
+                self.udp_run = False
+                self.udp_thread.join()
+        super(CollectorService, self).stop()
 
 
 class CollectorEndpoint(object):

--- a/ceilometer/notification.py
+++ b/ceilometer/notification.py
@@ -138,8 +138,8 @@ class NotificationService(service_base.PipelineBasedService):
 
         return event_pipe_manager
 
-    def run(self):
-        super(NotificationService, self).run()
+    def start(self):
+        super(NotificationService, self).start()
         self.shutdown = False
         self.periodic = None
         self.partition_coordinator = None
@@ -295,18 +295,19 @@ class NotificationService(service_base.PipelineBasedService):
         batch = (1 if self.conf.notification.batch_size > 1 else None)
         self.pipeline_listener.start(override_pool_size=batch)
 
-    def terminate(self):
-        self.shutdown = True
-        if self.periodic:
-            self.periodic.stop()
-            self.periodic.wait()
-        if self.partition_coordinator:
-            self.partition_coordinator.stop()
-        with self.coord_lock:
-            if self.pipeline_listener:
-                utils.kill_listeners([self.pipeline_listener])
-            utils.kill_listeners(self.listeners)
-        super(NotificationService, self).terminate()
+    def stop(self):
+        if self.started:
+            self.shutdown = True
+            if self.periodic:
+                self.periodic.stop()
+                self.periodic.wait()
+            if self.partition_coordinator:
+                self.partition_coordinator.stop()
+            with self.coord_lock:
+                if self.pipeline_listener:
+                    utils.kill_listeners([self.pipeline_listener])
+                utils.kill_listeners(self.listeners)
+        super(NotificationService, self).stop()
 
     def reload_pipeline(self):
         LOG.info(_LI("Reloading notification agent and listeners."))

--- a/ceilometer/service_base.py
+++ b/ceilometer/service_base.py
@@ -15,8 +15,8 @@
 
 import abc
 
-import cotyledon
 from oslo_log import log
+from oslo_service import service as os_service
 import six
 
 from ceilometer.i18n import _LE
@@ -26,10 +26,20 @@ from ceilometer import utils
 LOG = log.getLogger(__name__)
 
 
+class ServiceBase(os_service.Service):
+    def __init__(self):
+        self.started = False
+        super(ServiceBase, self).__init__()
+
+    def start(self):
+        self.started = True
+        super(ServiceBase, self).start()
+
+
 @six.add_metaclass(abc.ABCMeta)
-class PipelineBasedService(cotyledon.Service):
-    def __init__(self, worker_id, conf):
-        super(PipelineBasedService, self).__init__(worker_id)
+class PipelineBasedService(ServiceBase):
+    def __init__(self, conf):
+        super(PipelineBasedService, self).__init__()
         self.conf = conf
 
     def clear_pipeline_validation_status(self):
@@ -49,10 +59,11 @@ class PipelineBasedService(cotyledon.Service):
                 spacing=self.conf.pipeline_polling_interval)
             utils.spawn_thread(self.refresh_pipeline_periodic.start)
 
-    def terminate(self):
-        if self.refresh_pipeline_periodic:
+    def stop(self):
+        if self.started and self.refresh_pipeline_periodic:
             self.refresh_pipeline_periodic.stop()
             self.refresh_pipeline_periodic.wait()
+        super(PipelineBasedService, self).stop()
 
     @abc.abstractmethod
     def reload_pipeline(self):

--- a/ceilometer/tests/functional/test_collector.py
+++ b/ceilometer/tests/functional/test_collector.py
@@ -79,7 +79,7 @@ class TestCollector(tests_base.BaseTestCase):
             'not-so-secret')
 
         self.mock_dispatcher = self._setup_fake_dispatcher()
-        self.srv = collector.CollectorService(0, self.CONF)
+        self.srv = collector.CollectorService(self.CONF)
 
     def _setup_messaging(self, enabled=True):
         if enabled:
@@ -124,15 +124,13 @@ class TestCollector(tests_base.BaseTestCase):
 
         udp_socket = self._make_fake_socket(self.sample)
 
-        with mock.patch('select.select', return_value=([udp_socket], [], [])):
-            with mock.patch('socket.socket') as mock_socket:
-                mock_socket.return_value = udp_socket
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
-                mock_socket.assert_called_with(socket.AF_INET,
-                                               socket.SOCK_DGRAM)
+        with mock.patch('socket.socket') as mock_socket:
+            mock_socket.return_value = udp_socket
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
+            mock_socket.assert_called_with(socket.AF_INET, socket.SOCK_DGRAM)
 
         self._verify_udp_socket(udp_socket)
         mock_record = self.mock_dispatcher.record_metering_data
@@ -143,15 +141,13 @@ class TestCollector(tests_base.BaseTestCase):
         self.CONF.set_override('udp_address', '::1', group='collector')
         sock = self._make_fake_socket(self.sample)
 
-        with mock.patch('select.select', return_value=([sock], [], [])):
-            with mock.patch.object(socket, 'socket') as mock_socket:
-                mock_socket.return_value = sock
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
-                mock_socket.assert_called_with(socket.AF_INET6,
-                                               socket.SOCK_DGRAM)
+        with mock.patch.object(socket, 'socket') as mock_socket:
+            mock_socket.return_value = sock
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
+            mock_socket.assert_called_with(socket.AF_INET6, socket.SOCK_DGRAM)
 
     def test_udp_receive_storage_error(self):
         self._setup_messaging(False)
@@ -159,12 +155,11 @@ class TestCollector(tests_base.BaseTestCase):
         mock_record.side_effect = self._raise_error
 
         udp_socket = self._make_fake_socket(self.sample)
-        with mock.patch('select.select', return_value=([udp_socket], [], [])):
-            with mock.patch('socket.socket', return_value=udp_socket):
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
+        with mock.patch('socket.socket', return_value=udp_socket):
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
 
         self._verify_udp_socket(udp_socket)
 
@@ -178,13 +173,12 @@ class TestCollector(tests_base.BaseTestCase):
     def test_udp_receive_bad_decoding(self, log):
         self._setup_messaging(False)
         udp_socket = self._make_fake_socket(self.sample)
-        with mock.patch('select.select', return_value=([udp_socket], [], [])):
-            with mock.patch('socket.socket', return_value=udp_socket):
-                with mock.patch('msgpack.loads', self._raise_error):
-                    self.srv.run()
-                    self.addCleanup(self.srv.terminate)
-                    self.srv.udp_thread.join(5)
-                    self.assertFalse(self.srv.udp_thread.is_alive())
+        with mock.patch('socket.socket', return_value=udp_socket):
+            with mock.patch('msgpack.loads', self._raise_error):
+                self.srv.start()
+                self.addCleanup(self.srv.stop)
+                self.srv.udp_thread.join(5)
+                self.assertFalse(self.srv.udp_thread.is_alive())
 
         self._verify_udp_socket(udp_socket)
         log.warning.assert_called_once_with(
@@ -199,8 +193,8 @@ class TestCollector(tests_base.BaseTestCase):
         with mock.patch.object(oslo_messaging.MessageHandlingServer,
                                'start', side_effect=real_start) as rpc_start:
             with mock.patch('socket.socket', return_value=udp_socket):
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
+                self.srv.start()
+                self.addCleanup(self.srv.stop)
                 self.srv.udp_thread.join(5)
                 self.assertFalse(self.srv.udp_thread.is_alive())
                 self.assertEqual(0, rpc_start.call_count)
@@ -208,17 +202,17 @@ class TestCollector(tests_base.BaseTestCase):
 
     def test_udp_receive_valid_encoding(self):
         self._setup_messaging(False)
+        mock_dispatcher = self._setup_fake_dispatcher()
         self.data_sent = []
-        sock = self._make_fake_socket(self.utf8_msg)
-        with mock.patch('select.select', return_value=([sock], [], [])):
-            with mock.patch('socket.socket', return_value=sock):
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
-                self.assertTrue(utils.verify_signature(
-                    self.mock_dispatcher.method_calls[0][1][0],
-                    "not-so-secret"))
+        with mock.patch('socket.socket',
+                        return_value=self._make_fake_socket(self.utf8_msg)):
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
+            self.assertTrue(utils.verify_signature(
+                mock_dispatcher.method_calls[0][1][0],
+                "not-so-secret"))
 
     def _test_collector_requeue(self, listener, batch_listener=False):
 
@@ -227,8 +221,8 @@ class TestCollector(tests_base.BaseTestCase):
         mock_record.side_effect = Exception('boom')
         self.mock_dispatcher.record_events.side_effect = Exception('boom')
 
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
         endp = getattr(self.srv, listener).dispatcher.endpoints[0]
         ret = endp.sample([{'ctxt': {}, 'publisher_id': 'pub_id',
                             'event_type': 'event', 'payload': {},

--- a/ceilometer/tests/functional/test_notification.py
+++ b/ceilometer/tests/functional/test_notification.py
@@ -20,6 +20,7 @@ import time
 import mock
 from oslo_config import fixture as fixture_config
 import oslo_messaging
+import oslo_service.service
 from oslo_utils import fileutils
 import six
 from stevedore import extension
@@ -107,7 +108,7 @@ class TestNotification(tests_base.BaseTestCase):
         self.CONF.set_override("workload_partitioning", True,
                                group='notification')
         self.setup_messaging(self.CONF)
-        self.srv = notification.NotificationService(0, self.CONF)
+        self.srv = notification.NotificationService(self.CONF)
 
     def fake_get_notifications_manager(self, pm):
         self.plugin = _FakeNotificationPlugin(pm)
@@ -129,8 +130,8 @@ class TestNotification(tests_base.BaseTestCase):
         with mock.patch.object(self.srv,
                                '_get_notifications_manager') as get_nm:
             get_nm.side_effect = self.fake_get_notifications_manager
-            self.srv.run()
-        self.addCleanup(self.srv.terminate)
+            self.srv.start()
+        self.addCleanup(self.srv.stop)
         self.fake_event_endpoint = fake_event_endpoint_class.return_value
 
     def test_start_multiple_listeners(self):
@@ -173,11 +174,12 @@ class TestNotification(tests_base.BaseTestCase):
         with mock.patch.object(self.srv,
                                '_get_notifications_manager') as get_nm:
             get_nm.side_effect = fake_get_notifications_manager_dup_targets
-            self.srv.run()
-            self.addCleanup(self.srv.terminate)
-            self.assertEqual(2, len(mock_listener.call_args_list))
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.assertEqual(1, len(mock_listener.call_args_list))
             args, kwargs = mock_listener.call_args
-            self.assertEqual(1, len(self.srv.listeners))
+            self.assertEqual(1, len(args[1]))
+            self.assertIsInstance(args[1][0], oslo_messaging.Target)
 
 
 class BaseRealNotification(tests_base.BaseTestCase):
@@ -248,8 +250,8 @@ class BaseRealNotification(tests_base.BaseTestCase):
         self.publisher = test_publisher.TestPublisher(self.CONF, "")
 
     def _check_notification_service(self):
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
 
         notifier = messaging.get_notifier(self.transport,
                                           "compute.vagrant-precise")
@@ -274,21 +276,21 @@ class TestRealNotificationReloadablePipeline(BaseRealNotification):
         self.CONF.set_override('refresh_pipeline_cfg', True)
         self.CONF.set_override('refresh_event_pipeline_cfg', True)
         self.CONF.set_override('pipeline_polling_interval', 1)
-        self.srv = notification.NotificationService(0, self.CONF)
+        self.srv = notification.NotificationService(self.CONF)
 
     @mock.patch('ceilometer.publisher.test.TestPublisher')
     def test_notification_pipeline_poller(self, fake_publisher_cls):
         fake_publisher_cls.return_value = self.publisher
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
         self.assertIsNotNone(self.srv.refresh_pipeline_periodic)
 
     def test_notification_reloaded_pipeline(self):
         pipeline_cfg_file = self.setup_pipeline(['instance'])
         self.CONF.set_override("pipeline_cfg_file", pipeline_cfg_file)
 
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
 
         pipeline = self.srv.pipeline_manager.cfg_hash
 
@@ -310,8 +312,10 @@ class TestRealNotificationReloadablePipeline(BaseRealNotification):
             ['compute.instance.create.start'])
         self.CONF.set_override("event_pipeline_cfg_file", ev_pipeline_cfg_file)
 
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.CONF.set_override("store_events", True, group="notification")
+
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
 
         pipeline = self.srv.event_pipeline_manager.cfg_hash
 
@@ -334,7 +338,7 @@ class TestRealNotification(BaseRealNotification):
 
     def setUp(self):
         super(TestRealNotification, self).setUp()
-        self.srv = notification.NotificationService(0, self.CONF)
+        self.srv = notification.NotificationService(self.CONF)
 
     @mock.patch('ceilometer.publisher.test.TestPublisher')
     def test_notification_service(self, fake_publisher_cls):
@@ -344,8 +348,8 @@ class TestRealNotification(BaseRealNotification):
     @mock.patch('ceilometer.publisher.test.TestPublisher')
     def test_notification_service_error_topic(self, fake_publisher_cls):
         fake_publisher_cls.return_value = self.publisher
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
         notifier = messaging.get_notifier(self.transport,
                                           'compute.vagrant-precise')
         notifier.error({}, 'compute.instance.error',
@@ -363,7 +367,7 @@ class TestRealNotificationHA(BaseRealNotification):
         super(TestRealNotificationHA, self).setUp()
         self.CONF.set_override('workload_partitioning', True,
                                group='notification')
-        self.srv = notification.NotificationService(0, self.CONF)
+        self.srv = notification.NotificationService(self.CONF)
 
     @mock.patch('ceilometer.publisher.test.TestPublisher')
     def test_notification_service(self, fake_publisher_cls):
@@ -388,8 +392,8 @@ class TestRealNotificationHA(BaseRealNotification):
             mock.MagicMock(),  # refresh pipeline listener
         ]
 
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
 
         def _check_listener_targets():
             args, kwargs = mock_listener.call_args
@@ -408,8 +412,8 @@ class TestRealNotificationHA(BaseRealNotification):
     def test_retain_common_targets_on_refresh(self, mock_listener):
         with mock.patch('ceilometer.coordination.PartitionCoordinator'
                         '.extract_my_subset', return_value=[1, 2]):
-            self.srv.run()
-            self.addCleanup(self.srv.terminate)
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
         listened_before = [target.topic for target in
                            mock_listener.call_args[0][1]]
         self.assertEqual(4, len(listened_before))
@@ -425,8 +429,8 @@ class TestRealNotificationHA(BaseRealNotification):
 
     @mock.patch('oslo_messaging.get_batch_notification_listener')
     def test_notify_to_relevant_endpoint(self, mock_listener):
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
 
         targets = mock_listener.call_args[0][1]
         self.assertIsNotEmpty(targets)
@@ -448,8 +452,8 @@ class TestRealNotificationHA(BaseRealNotification):
 
     @mock.patch('oslo_messaging.Notifier.sample')
     def test_broadcast_to_relevant_pipes_only(self, mock_notifier):
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
         for endpoint in self.srv.listeners[0].dispatcher.endpoints:
             if (hasattr(endpoint, 'filter_rule') and
                 not endpoint.filter_rule.match(None, None, 'nonmatching.end',
@@ -542,16 +546,16 @@ class TestRealNotificationMultipleAgents(tests_base.BaseTestCase):
     def _check_notifications(self, fake_publisher_cls):
         fake_publisher_cls.side_effect = [self.publisher, self.publisher2]
 
-        self.srv = notification.NotificationService(0, self.CONF)
-        self.srv2 = notification.NotificationService(0, self.CONF)
+        self.srv = notification.NotificationService(self.CONF)
+        self.srv2 = notification.NotificationService(self.CONF)
         with mock.patch('ceilometer.coordination.PartitionCoordinator'
                         '._get_members', return_value=['harry', 'lloyd']):
             with mock.patch('uuid.uuid4', return_value='harry'):
-                self.srv.run()
-            self.addCleanup(self.srv.terminate)
+                self.srv.start()
+            self.addCleanup(self.srv.stop)
             with mock.patch('uuid.uuid4', return_value='lloyd'):
-                self.srv2.run()
-            self.addCleanup(self.srv2.terminate)
+                self.srv2.start()
+            self.addCleanup(self.srv2.stop)
 
         notifier = messaging.get_notifier(self.transport,
                                           "compute.vagrant-precise")

--- a/ceilometer/tests/unit/agent/agentbase.py
+++ b/ceilometer/tests/unit/agent/agentbase.py
@@ -298,7 +298,7 @@ class BaseAgentManagerTestCase(base.BaseTestCase):
         mpc.is_active.return_value = False
         self.CONF.set_override('heartbeat', 1.0, group='coordination')
         self.mgr.partition_coordinator.heartbeat = mock.MagicMock()
-        self.mgr.run()
+        self.mgr.start()
         setup_polling.assert_called_once_with(self.CONF)
         mpc.start.assert_called_once_with()
         self.assertEqual(2, mpc.join_group.call_count)
@@ -313,8 +313,37 @@ class BaseAgentManagerTestCase(base.BaseTestCase):
             time.sleep(0.5)
         self.assertGreaterEqual(1, runs)
 
-        self.mgr.terminate()
+        self.mgr.stop()
         mpc.stop.assert_called_once_with()
+
+    @mock.patch('ceilometer.pipeline.setup_polling')
+    def test_start_with_pipeline_poller(self, setup_polling):
+        self.mgr.setup_polling_tasks = mock.MagicMock()
+        mpc = self.mgr.partition_coordinator
+        mpc.is_active.return_value = False
+        self.CONF.set_override('heartbeat', 1.0, group='coordination')
+        self.mgr.partition_coordinator.heartbeat = mock.MagicMock()
+
+        self.CONF.set_override('refresh_pipeline_cfg', True)
+        self.CONF.set_override('pipeline_polling_interval', 5)
+        self.addCleanup(self.mgr.stop)
+        self.mgr.start()
+        self.addCleanup(self.mgr.stop)
+        setup_polling.assert_called_once_with()
+        mpc.start.assert_called_once_with()
+        self.assertEqual(2, mpc.join_group.call_count)
+        self.mgr.setup_polling_tasks.assert_called_once_with()
+
+        # Wait first heatbeat
+        runs = 0
+        for i in six.moves.range(10):
+            runs = list(self.mgr.heartbeat_timer.iter_watchers())[0].runs
+            if runs > 0:
+                break
+            time.sleep(0.5)
+        self.assertGreaterEqual(1, runs)
+
+        self.assertEqual([], list(self.mgr.polling_periodics.iter_watchers()))
 
     def test_join_partitioning_groups(self):
         self.mgr.discoveries = self.create_discoveries()
@@ -388,8 +417,8 @@ class BaseAgentManagerTestCase(base.BaseTestCase):
         mgr = self.create_manager()
         mgr.extensions = self.mgr.extensions
         mgr.create_polling_task = mock.MagicMock()
-        mgr.run()
-        self.addCleanup(mgr.terminate)
+        mgr.start()
+        self.addCleanup(mgr.stop)
         mgr.create_polling_task.assert_called_once_with()
 
     def test_agent_manager_start_fallback(self):

--- a/ceilometer/tests/unit/agent/test_manager.py
+++ b/ceilometer/tests/unit/agent/test_manager.py
@@ -19,6 +19,7 @@ import shutil
 from keystoneauth1 import exceptions as ka_exceptions
 import mock
 from oslo_config import fixture as fixture_config
+from oslo_service import service as os_service
 from oslo_utils import fileutils
 from oslotest import base
 from oslotest import mockpatch
@@ -426,10 +427,11 @@ class TestRunTasks(agentbase.BaseAgentManagerTestCase):
                 'publishers': ["test"]}]
         }
 
-        self.mgr.polling_manager = pipeline.PollingManager(
-            self.CONF,
-            self.cfg2file(pipeline_cfg))
-        polling_task = list(self.mgr.setup_polling_tasks().values())[0]
+        self.mgr.start()
+        self.addCleanup(self.mgr.stop)
+        # Manually executes callbacks
+        for cb, __, args, kwargs in self.mgr.polling_periodics._callables:
+            cb(*args, **kwargs)
 
         self.mgr.interval_task(polling_task)
         samples = self.notified_samples
@@ -458,8 +460,9 @@ class TestRunTasks(agentbase.BaseAgentManagerTestCase):
         pipeline_cfg_file = self.setup_pipeline_file(pipeline)
 
         self.CONF.set_override("pipeline_cfg_file", pipeline_cfg_file)
-        self.mgr.run()
-        self.addCleanup(self.mgr.terminate)
+        self.mgr.tg = os_service.threadgroup.ThreadGroup(1000)
+        self.mgr.start()
+        self.addCleanup(self.mgr.stop)
 
         # we only got the old name of meters
         for sample in self.notified_samples:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 cachetools>=1.1.0 # MIT License
-cotyledon>=1.3.0 #Apache-2.0
 futures>=3.0;python_version=='2.7' or python_version=='2.6' # BSD
 futurist>=0.11.0 # Apache-2.0
 debtcollector>=1.2.0 # Apache-2.0
@@ -22,6 +21,7 @@ oslo.log>=1.14.0 # Apache-2.0
 oslo.policy>=0.5.0 # Apache-2.0
 oslo.reports>=0.6.0 # Apache-2.0
 oslo.rootwrap>=2.0.0 # Apache-2.0
+oslo.service>=1.0.0 # Apache-2.0
 PasteDeploy>=1.5.0 # MIT
 pbr>=1.6 # Apache-2.0
 pecan>=1.0.0 # BSD


### PR DESCRIPTION
This reverts commit 80bc124511720c12182fe64dcae821f4f3e3d111.

Conflicts:
	ceilometer/collector.py
	ceilometer/tests/functional/test_collector.py
	ceilometer/tests/functional/test_notification.py
	ceilometer/tests/unit/agent/agentbase.py
	ceilometer/tests/unit/agent/test_manager.py

Change-Id: I7b99ddd69beae2839289262a96cb1421ab10de84
(cherry picked from commit ce7efabfd82a3639b5f09372b5aa17f646e75da0)

Conflicts:
	ceilometer/agent/manager.py
	ceilometer/cmd/agent_notification.py
	ceilometer/cmd/collector.py
	ceilometer/cmd/polling.py
	ceilometer/collector.py
	ceilometer/service_base.py
	ceilometer/tests/functional/test_collector.py
	ceilometer/tests/functional/test_notification.py
	ceilometer/tests/unit/agent/agentbase.py
	ceilometer/tests/unit/agent/test_manager.py
	requirements.txt