### PR TITLE
Revert "move out oslo.service"

### DIFF
--- a/ceilometer/cmd/agent_notification.py
+++ b/ceilometer/cmd/agent_notification.py
@@ -14,8 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import cotyledon
-from cotyledon import oslo_config_glue
+from oslo_service import service as os_service
 
 from ceilometer import notification
 from ceilometer import service
@@ -23,9 +22,5 @@ from ceilometer import service
 
 def main():
     conf = service.prepare_service()
-
-    sm = cotyledon.ServiceManager()
-    sm.add(notification.NotificationService,
-           workers=conf.notification.workers, args=(conf,))
-    oslo_config_glue.setup(sm, conf)
-    sm.run()
+    os_service.launch(conf, notification.NotificationService(),
+                      workers=conf.notification.workers).wait()

--- a/ceilometer/cmd/collector.py
+++ b/ceilometer/cmd/collector.py
@@ -14,8 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import cotyledon
-from cotyledon import oslo_config_glue
+from oslo_service import service as os_service
 
 from ceilometer import collector
 from ceilometer import service
@@ -23,8 +22,5 @@ from ceilometer import service
 
 def main():
     conf = service.prepare_service()
-    sm = cotyledon.ServiceManager()
-    sm.add(collector.CollectorService, workers=conf.collector.workers,
-           args=(conf,))
-    oslo_config_glue.setup(sm, conf)
-    sm.run()
+    os_service.launch(conf, collector.CollectorService(),
+                      workers=conf.collector.workers).wait()

--- a/ceilometer/cmd/polling.py
+++ b/ceilometer/cmd/polling.py
@@ -14,10 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import cotyledon
-from cotyledon import oslo_config_glue
 from oslo_config import cfg
 from oslo_log import log
+from oslo_service import service as os_service
 
 from ceilometer.agent import manager
 from ceilometer import service
@@ -76,18 +75,9 @@ CLI_OPTS = [
 ]
 
 
-def create_polling_service(worker_id, conf):
-    return manager.AgentManager(worker_id,
-                                conf,
-                                conf.polling_namespaces,
-                                conf.pollster_list)
-
-
 def main():
     conf = cfg.ConfigOpts()
     conf.register_cli_opts(CLI_OPTS)
     service.prepare_service(conf=conf)
-    sm = cotyledon.ServiceManager()
-    sm.add(create_polling_service, args=(conf,))
-    oslo_config_glue.setup(sm, conf)
-    sm.run()
+    os_service.launch(conf, manager.AgentManager(conf, conf.polling_namespaces,
+                                                 conf.pollster_list)).wait()

--- a/ceilometer/service_base.py
+++ b/ceilometer/service_base.py
@@ -1,0 +1,119 @@
+#
+# Copyright 2015 Hewlett Packard
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import abc
+
+from oslo_log import log
+from oslo_service import service as os_service
+import six
+
+from ceilometer import pipeline
+from ceilometer import utils
+
+LOG = log.getLogger(__name__)
+
+
+class ServiceBase(os_service.Service):
+    def __init__(self):
+        self.started = False
+        super(ServiceBase, self).__init__()
+
+    def start(self):
+        self.started = True
+        super(ServiceBase, self).start()
+
+
+@six.add_metaclass(abc.ABCMeta)
+class PipelineBasedService(ServiceBase):
+    def __init__(self, conf):
+        super(PipelineBasedService, self).__init__()
+        self.conf = conf
+
+    def clear_pipeline_validation_status(self):
+        """Clears pipeline validation status flags."""
+        self.pipeline_validated = False
+        self.event_pipeline_validated = False
+
+    def init_pipeline_refresh(self):
+        """Initializes pipeline refresh state."""
+        self.clear_pipeline_validation_status()
+
+        self.refresh_pipeline_periodic = None
+        if (self.conf.refresh_pipeline_cfg or
+                self.conf.refresh_event_pipeline_cfg):
+            self.refresh_pipeline_periodic = utils.create_periodic(
+                target=self.refresh_pipeline,
+                spacing=self.conf.pipeline_polling_interval)
+            utils.spawn_thread(self.refresh_pipeline_periodic.start)
+
+    def stop(self):
+        if self.started and self.refresh_pipeline_periodic:
+            self.refresh_pipeline_periodic.stop()
+            self.refresh_pipeline_periodic.wait()
+        super(PipelineBasedService, self).stop()
+
+    @abc.abstractmethod
+    def reload_pipeline(self):
+        """Reload pipeline in the agents."""
+
+    def refresh_pipeline(self):
+        """Refreshes appropriate pipeline, then delegates to agent."""
+
+        if self.conf.refresh_pipeline_cfg:
+            manager = None
+            if hasattr(self, 'pipeline_manager'):
+                manager = self.pipeline_manager
+            elif hasattr(self, 'polling_manager'):
+                manager = self.polling_manager
+            pipeline_hash = manager.cfg_changed() if manager else None
+            if pipeline_hash:
+                try:
+                    LOG.debug("Pipeline has been refreshed. "
+                              "old hash: %(old)s, new hash: %(new)s",
+                              {'old': manager.cfg_hash,
+                               'new': pipeline_hash})
+                    # Pipeline in the notification agent.
+                    if hasattr(self, 'pipeline_manager'):
+                        self.pipeline_manager = pipeline.setup_pipeline(
+                            self.conf)
+                    # Polling in the polling agent.
+                    elif hasattr(self, 'polling_manager'):
+                        self.polling_manager = pipeline.setup_polling(
+                            self.conf)
+                    self.pipeline_validated = True
+                except Exception as err:
+                    LOG.exception('Unable to load changed pipeline: %s' % err)
+
+        if self.conf.refresh_event_pipeline_cfg:
+            # Pipeline in the notification agent.
+            manager = (self.event_pipeline_manager
+                       if hasattr(self, 'event_pipeline_manager') else None)
+            ev_pipeline_hash = manager.cfg_changed()
+            if ev_pipeline_hash:
+                try:
+                    LOG.debug("Event Pipeline has been refreshed. "
+                              "old hash: %(old)s, new hash: %(new)s",
+                              {'old': manager.cfg_hash,
+                               'new': ev_pipeline_hash})
+                    self.event_pipeline_manager = (
+                        pipeline. setup_event_pipeline(self.conf))
+                    self.event_pipeline_validated = True
+                except Exception as err:
+                    LOG.exception('Unable to load changed event pipeline:'
+                                      ' %s' % err)
+
+        if self.pipeline_validated or self.event_pipeline_validated:
+            self.reload_pipeline()
+            self.clear_pipeline_validation_status()

--- a/ceilometer/tests/functional/test_collector.py
+++ b/ceilometer/tests/functional/test_collector.py
@@ -78,7 +78,7 @@ class TestCollector(tests_base.BaseTestCase):
             'not-so-secret')
 
         self.mock_dispatcher = self._setup_fake_dispatcher()
-        self.srv = collector.CollectorService(0, self.CONF)
+        self.srv = collector.CollectorService(self.CONF)
 
     def _setup_messaging(self, enabled=True):
         if enabled:
@@ -123,15 +123,13 @@ class TestCollector(tests_base.BaseTestCase):
 
         udp_socket = self._make_fake_socket(self.sample)
 
-        with mock.patch('select.select', return_value=([udp_socket], [], [])):
-            with mock.patch('socket.socket') as mock_socket:
-                mock_socket.return_value = udp_socket
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
-                mock_socket.assert_called_with(socket.AF_INET,
-                                               socket.SOCK_DGRAM)
+        with mock.patch('socket.socket') as mock_socket:
+            mock_socket.return_value = udp_socket
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
+            mock_socket.assert_called_with(socket.AF_INET, socket.SOCK_DGRAM)
 
         self._verify_udp_socket(udp_socket)
         mock_record = self.mock_dispatcher.record_metering_data
@@ -142,15 +140,13 @@ class TestCollector(tests_base.BaseTestCase):
         self.CONF.set_override('udp_address', '::1', group='collector')
         sock = self._make_fake_socket(self.sample)
 
-        with mock.patch('select.select', return_value=([sock], [], [])):
-            with mock.patch.object(socket, 'socket') as mock_socket:
-                mock_socket.return_value = sock
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
-                mock_socket.assert_called_with(socket.AF_INET6,
-                                               socket.SOCK_DGRAM)
+        with mock.patch.object(socket, 'socket') as mock_socket:
+            mock_socket.return_value = sock
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
+            mock_socket.assert_called_with(socket.AF_INET6, socket.SOCK_DGRAM)
 
     def test_udp_receive_storage_error(self):
         self._setup_messaging(False)
@@ -158,12 +154,11 @@ class TestCollector(tests_base.BaseTestCase):
         mock_record.side_effect = self._raise_error
 
         udp_socket = self._make_fake_socket(self.sample)
-        with mock.patch('select.select', return_value=([udp_socket], [], [])):
-            with mock.patch('socket.socket', return_value=udp_socket):
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
+        with mock.patch('socket.socket', return_value=udp_socket):
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
 
         self._verify_udp_socket(udp_socket)
 
@@ -177,13 +172,12 @@ class TestCollector(tests_base.BaseTestCase):
     def test_udp_receive_bad_decoding(self, log):
         self._setup_messaging(False)
         udp_socket = self._make_fake_socket(self.sample)
-        with mock.patch('select.select', return_value=([udp_socket], [], [])):
-            with mock.patch('socket.socket', return_value=udp_socket):
-                with mock.patch('msgpack.loads', self._raise_error):
-                    self.srv.run()
-                    self.addCleanup(self.srv.terminate)
-                    self.srv.udp_thread.join(5)
-                    self.assertFalse(self.srv.udp_thread.is_alive())
+        with mock.patch('socket.socket', return_value=udp_socket):
+            with mock.patch('msgpack.loads', self._raise_error):
+                self.srv.start()
+                self.addCleanup(self.srv.stop)
+                self.srv.udp_thread.join(5)
+                self.assertFalse(self.srv.udp_thread.is_alive())
 
         self._verify_udp_socket(udp_socket)
         log.warning.assert_called_once_with(
@@ -198,8 +192,8 @@ class TestCollector(tests_base.BaseTestCase):
         with mock.patch.object(oslo_messaging.MessageHandlingServer,
                                'start', side_effect=real_start) as rpc_start:
             with mock.patch('socket.socket', return_value=udp_socket):
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
+                self.srv.start()
+                self.addCleanup(self.srv.stop)
                 self.srv.udp_thread.join(5)
                 self.assertFalse(self.srv.udp_thread.is_alive())
                 self.assertEqual(0, rpc_start.call_count)
@@ -207,17 +201,17 @@ class TestCollector(tests_base.BaseTestCase):
 
     def test_udp_receive_valid_encoding(self):
         self._setup_messaging(False)
+        mock_dispatcher = self._setup_fake_dispatcher()
         self.data_sent = []
-        sock = self._make_fake_socket(self.utf8_msg)
-        with mock.patch('select.select', return_value=([sock], [], [])):
-            with mock.patch('socket.socket', return_value=sock):
-                self.srv.run()
-                self.addCleanup(self.srv.terminate)
-                self.srv.udp_thread.join(5)
-                self.assertFalse(self.srv.udp_thread.is_alive())
-                self.assertTrue(utils.verify_signature(
-                    self.mock_dispatcher.method_calls[0][1][0],
-                    "not-so-secret"))
+        with mock.patch('socket.socket',
+                        return_value=self._make_fake_socket(self.utf8_msg)):
+            self.srv.start()
+            self.addCleanup(self.srv.stop)
+            self.srv.udp_thread.join(5)
+            self.assertFalse(self.srv.udp_thread.is_alive())
+            self.assertTrue(utils.verify_signature(
+                mock_dispatcher.method_calls[0][1][0],
+                "not-so-secret"))
 
     def _test_collector_requeue(self, listener, batch_listener=False):
 
@@ -226,8 +220,8 @@ class TestCollector(tests_base.BaseTestCase):
         mock_record.side_effect = Exception('boom')
         self.mock_dispatcher.record_events.side_effect = Exception('boom')
 
-        self.srv.run()
-        self.addCleanup(self.srv.terminate)
+        self.srv.start()
+        self.addCleanup(self.srv.stop)
         endp = getattr(self.srv, listener).dispatcher.endpoints[0]
         ret = endp.sample([{'ctxt': {}, 'publisher_id': 'pub_id',
                             'event_type': 'event', 'payload': {},

--- a/ceilometer/tests/unit/agent/agentbase.py
+++ b/ceilometer/tests/unit/agent/agentbase.py
@@ -294,10 +294,41 @@ class BaseAgentManagerTestCase(base.BaseTestCase):
     @mock.patch('ceilometer.pipeline.setup_polling')
     def test_start(self, setup_polling):
         self.mgr.setup_polling_tasks = mock.MagicMock()
-        self.mgr.run()
+        self.mgr.start()
         setup_polling.assert_called_once_with(self.CONF)
         self.mgr.setup_polling_tasks.assert_called_once_with()
-        self.mgr.terminate()
+
+        self.mgr.stop()
+        mpc.stop.assert_called_once_with()
+
+    @mock.patch('ceilometer.pipeline.setup_polling')
+    def test_start_with_pipeline_poller(self, setup_polling):
+        self.mgr.setup_polling_tasks = mock.MagicMock()
+        mpc = self.mgr.partition_coordinator
+        mpc.is_active.return_value = False
+        self.CONF.set_override('heartbeat', 1.0, group='coordination')
+        self.mgr.partition_coordinator.heartbeat = mock.MagicMock()
+
+        self.CONF.set_override('refresh_pipeline_cfg', True)
+        self.CONF.set_override('pipeline_polling_interval', 5)
+        self.addCleanup(self.mgr.stop)
+        self.mgr.start()
+        self.addCleanup(self.mgr.stop)
+        setup_polling.assert_called_once_with()
+        mpc.start.assert_called_once_with()
+        self.assertEqual(2, mpc.join_group.call_count)
+        self.mgr.setup_polling_tasks.assert_called_once_with()
+
+        # Wait first heatbeat
+        runs = 0
+        for i in six.moves.range(10):
+            runs = list(self.mgr.heartbeat_timer.iter_watchers())[0].runs
+            if runs > 0:
+                break
+            time.sleep(0.5)
+        self.assertGreaterEqual(1, runs)
+
+        self.assertEqual([], list(self.mgr.polling_periodics.iter_watchers()))
 
     def test_setup_polling_tasks(self):
         polling_tasks = self.mgr.setup_polling_tasks()
@@ -358,8 +389,8 @@ class BaseAgentManagerTestCase(base.BaseTestCase):
         mgr = self.create_manager()
         mgr.extensions = self.mgr.extensions
         mgr.create_polling_task = mock.MagicMock()
-        mgr.run()
-        self.addCleanup(mgr.terminate)
+        mgr.start()
+        self.addCleanup(mgr.stop)
         mgr.create_polling_task.assert_called_once_with()
 
     def test_agent_manager_start_fallback(self):

--- a/ceilometer/tests/unit/agent/test_manager.py
+++ b/ceilometer/tests/unit/agent/test_manager.py
@@ -16,6 +16,7 @@
 import fixtures
 from keystoneauth1 import exceptions as ka_exceptions
 import mock
+from oslo_service import service as os_service
 from oslo_utils import fileutils
 from oslotest import base
 import six
@@ -452,10 +453,11 @@ class TestRunTasks(agentbase.BaseAgentManagerTestCase):
                 'publishers': ["test"]}]
         }
 
-        self.mgr.polling_manager = pipeline.PollingManager(
-            self.CONF,
-            self.cfg2file(pipeline_cfg))
-        polling_task = list(self.mgr.setup_polling_tasks().values())[0]
+        self.mgr.start()
+        self.addCleanup(self.mgr.stop)
+        # Manually executes callbacks
+        for cb, __, args, kwargs in self.mgr.polling_periodics._callables:
+            cb(*args, **kwargs)
 
         self.mgr.interval_task(polling_task)
         samples = self.notified_samples

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # process, which may cause wedges in the gate later.
 
 cachetools>=1.1.0 # MIT License
-cotyledon>=1.3.0 #Apache-2.0
 futures>=3.0;python_version=='2.7' or python_version=='2.6' # BSD
 futurist>=0.11.0 # Apache-2.0
 debtcollector>=1.2.0 # Apache-2.0
@@ -22,6 +21,7 @@ oslo.log>=1.14.0 # Apache-2.0
 oslo.policy>=0.5.0 # Apache-2.0
 oslo.reports>=0.6.0 # Apache-2.0
 oslo.rootwrap>=2.0.0 # Apache-2.0
+oslo.service>=1.0.0 # Apache-2.0
 PasteDeploy>=1.5.0 # MIT
 pbr>=1.6 # Apache-2.0
 pecan>=1.0.0 # BSD


### PR DESCRIPTION
This reverts commit 80bc124511720c12182fe64dcae821f4f3e3d111.

Conflicts:
	ceilometer/collector.py
	ceilometer/tests/functional/test_collector.py
	ceilometer/tests/functional/test_notification.py
	ceilometer/tests/unit/agent/agentbase.py
	ceilometer/tests/unit/agent/test_manager.py

Change-Id: I7b99ddd69beae2839289262a96cb1421ab10de84
(cherry picked from commit ce7efabfd82a3639b5f09372b5aa17f646e75da0)

Conflicts:
	ceilometer/agent/manager.py
	ceilometer/cmd/agent_notification.py
	ceilometer/cmd/collector.py
	ceilometer/cmd/polling.py
	ceilometer/collector.py
	ceilometer/service_base.py
	ceilometer/tests/functional/test_collector.py
	ceilometer/tests/functional/test_notification.py
	ceilometer/tests/unit/agent/agentbase.py
	ceilometer/tests/unit/agent/test_manager.py
	requirements.txt

(cherry picked from commit ad8063dc5fc76173bda158aed49269ce2a287924)

Conflicts:
	ceilometer/agent/manager.py
	ceilometer/collector.py
	ceilometer/notification.py
	ceilometer/service_base.py
	ceilometer/tests/functional/test_notification.py
	ceilometer/tests/unit/agent/agentbase.py
	ceilometer/tests/unit/agent/test_manager.py